### PR TITLE
Fix returning `nil` for falsey values when no block is given

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,15 +1,19 @@
 example_id                      | status | run_time        |
 ------------------------------- | ------ | --------------- |
-./spec/dig/block_spec.rb[1:1]   | passed | 0.00058 seconds |
-./spec/dig/block_spec.rb[1:2:1] | passed | 0.00043 seconds |
-./spec/dig/block_spec.rb[1:2:2] | passed | 0.00005 seconds |
-./spec/dig/block_spec.rb[1:2:3] | passed | 0.00005 seconds |
-./spec/dig/block_spec.rb[1:3:1] | passed | 0.00004 seconds |
-./spec/dig/block_spec.rb[1:3:2] | passed | 0.00004 seconds |
-./spec/dig/block_spec.rb[1:3:3] | passed | 0.00005 seconds |
-./spec/dig/block_spec.rb[1:4:1] | passed | 0.0001 seconds  |
-./spec/dig/block_spec.rb[1:4:2] | passed | 0.00014 seconds |
-./spec/dig/block_spec.rb[1:4:3] | passed | 0.00006 seconds |
-./spec/dig/block_spec.rb[1:5:1] | passed | 0.0001 seconds  |
-./spec/dig/block_spec.rb[1:5:2] | passed | 0.00006 seconds |
-./spec/dig/block_spec.rb[1:5:3] | passed | 0.00006 seconds |
+./spec/dig/block_spec.rb[1:1]   | passed | 0.00093 seconds |
+./spec/dig/block_spec.rb[1:2:1] | passed | 0.00052 seconds |
+./spec/dig/block_spec.rb[1:2:2] | passed | 0.00011 seconds |
+./spec/dig/block_spec.rb[1:2:3] | passed | 0.00009 seconds |
+./spec/dig/block_spec.rb[1:2:4] | passed | 0.00012 seconds |
+./spec/dig/block_spec.rb[1:3:1] | passed | 0.0001 seconds  |
+./spec/dig/block_spec.rb[1:3:2] | passed | 0.00008 seconds |
+./spec/dig/block_spec.rb[1:3:3] | passed | 0.00007 seconds |
+./spec/dig/block_spec.rb[1:3:4] | passed | 0.00009 seconds |
+./spec/dig/block_spec.rb[1:4:1] | passed | 0.00017 seconds |
+./spec/dig/block_spec.rb[1:4:2] | passed | 0.00038 seconds |
+./spec/dig/block_spec.rb[1:4:3] | passed | 0.00015 seconds |
+./spec/dig/block_spec.rb[1:4:4] | passed | 0.00024 seconds |
+./spec/dig/block_spec.rb[1:5:1] | passed | 0.00019 seconds |
+./spec/dig/block_spec.rb[1:5:2] | passed | 0.00027 seconds |
+./spec/dig/block_spec.rb[1:5:3] | passed | 0.00016 seconds |
+./spec/dig/block_spec.rb[1:5:4] | passed | 0.00016 seconds |

--- a/lib/dig/block.rb
+++ b/lib/dig/block.rb
@@ -5,7 +5,7 @@ module Dig
   module Block
     def dig(*)
       ret = super
-      return ret if ret
+      return ret unless ret.nil?
       yield if block_given?
     end
   end

--- a/spec/dig/block_spec.rb
+++ b/spec/dig/block_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Dig::Block do
       expect([1, [2]].dig(1, 0)).to eq(2)
     end
 
+    it "Returning false if the nested value is false. (Fixes Issue #1)" do
+      expect([1, [false]].dig(1, 0)).to eq(false)
+    end
+
     it "Returning nil if any intermediate step is nil." do
       expect([1, [2]].dig(1, 1)).to eq(nil)
     end
@@ -22,6 +26,10 @@ RSpec.describe Dig::Block do
       expect({ a: 1, b: { c: 2 }}.dig(:b, :c)).to eq(2)
     end
 
+    it "Returning false if the nested value is false. (Fixes Issue #1)" do
+      expect({ a: 1, b: { c: false }}.dig(:b, :c)).to eq(false)
+    end
+
     it "Returning nil if any intermediate step is nil." do
       expect({ a: 1}.dig(:b, 1)).to eq(nil)
     end
@@ -32,11 +40,15 @@ RSpec.describe Dig::Block do
   end
 
   context Struct do
-    let(:nested_object) { Struct.new(:value).new(2) }
+    let(:nested_object) { Struct.new(:value, :false_value).new(2, false) }
     let(:object) { Struct.new(:nested_object).new(nested_object) }
 
     it "Extracts the nested value specified by the sequence of idx objects by calling dig at each step." do
       expect(object.dig(:nested_object, :value)).to eq(2)
+    end
+
+    it "Returning false if the nested value is false. (Fixes Issue #1)" do
+      expect(object.dig(:nested_object, :false_value)).to eq(false)
     end
 
     it "Returning nil if any intermediate step is nil." do
@@ -49,11 +61,15 @@ RSpec.describe Dig::Block do
   end
 
   context OpenStruct do
-    let(:nested_object) { OpenStruct.new(value: 2) }
+    let(:nested_object) { OpenStruct.new(value: 2, false_value: false) }
     let(:object) { OpenStruct.new(nested_object: nested_object) }
 
     it "Extracts the nested value specified by the sequence of idx objects by calling dig at each step." do
       expect(object.dig(:nested_object, :value)).to eq(2)
+    end
+
+    it "Returning false if the nested value is false. (Fixes Issue #1)" do
+      expect(object.dig(:nested_object, :false_value)).to eq(false)
     end
 
     it "Returning nil if any intermediate step is nil." do


### PR DESCRIPTION
The example where this bit us is `dry-rb`, which accesses the values of a validated schema using `dig`. If a key with a boolean value was requested (and the value was `false`), `dig-block` does not return the value but tries to run a block (if given. If there is no block (dry-rb does not have one), it returns (resulting in `nil` instead of `false`).